### PR TITLE
Add description embeddings via transformers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ torch==2.0.1
 scikit-learn==1.3.0
 xgboost==1.7.6
 shap==0.42.1
+transformers==4.34.1
 
 # Data Processing
 joblib==1.3.2

--- a/src/ml/nlp_features.py
+++ b/src/ml/nlp_features.py
@@ -1,0 +1,29 @@
+import logging
+from typing import List
+
+import numpy as np
+import torch
+from transformers import AutoModel, AutoTokenizer
+
+logger = logging.getLogger(__name__)
+
+
+class DescriptionEmbedder:
+    """Encode account descriptions into embeddings using a transformer model."""
+
+    def __init__(self, model_name: str = "distilbert-base-uncased") -> None:
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModel.from_pretrained(model_name)
+        self.dim = self.model.config.hidden_size
+        logger.info("Loaded transformer model %s", model_name)
+
+    def encode_batch(self, texts: List[str]) -> np.ndarray:
+        """Return embeddings for a batch of texts."""
+        if not texts:
+            return np.zeros((0, self.dim))
+
+        inputs = self.tokenizer(texts, padding=True, truncation=True, return_tensors="pt")
+        with torch.no_grad():
+            outputs = self.model(**inputs)
+            embeddings = outputs.last_hidden_state.mean(dim=1).cpu().numpy()
+        return embeddings

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -440,12 +440,12 @@ class CrossSellOrchestrator:
 
         # Generate 1000 synthetic samples
         n_samples = 1000
-        n_features = 6  # Match the feature engineering
+        n_features = 6 + self.feature_engineer.description_dim
 
         # Create synthetic features
         X = np.random.rand(n_samples, n_features)
 
-        # Create labels based on some logic
+        # Create labels based on some logic using the first six features
         y = []
         for features in X:
             score = (

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -15,6 +15,16 @@ import pytest
 from httpx import AsyncClient
 
 
+def torch_available():
+    """Check if PyTorch is available"""
+    try:
+        import torch  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 # Test fixtures
 @pytest.fixture
 def salesforce_config():
@@ -422,16 +432,6 @@ class TestIntegration:
 
 
 # ============= Utility Functions =============
-
-
-def torch_available():
-    """Check if PyTorch is available"""
-    try:
-        import torch
-
-        return True
-    except ImportError:
-        return False
 
 
 # ============= Test Configuration =============


### PR DESCRIPTION
## Summary
- add NLP embedder using `transformers`
- extend `FeatureEngineering` to compute description embeddings
- update synthetic training data generation for new features
- add `transformers` dependency
- adjust tests for torch availability function

## Testing
- `pytest -q` *(fails: asyncio fixture, TypeError AsyncClient init, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687cf3dfbf9c83328beb68b2d3481f34