### PR TITLE
Implement data normalization processing

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -298,15 +298,60 @@ class CrossSellOrchestrator:
             await session.commit()
 
     async def _process_data(self, org_data: Dict[str, Dict]) -> Dict[str, Any]:
-        """Process extracted data for ML pipeline"""
-        processed = {"org_data": org_data, "feature_matrix": None, "labels": None}
+        """Clean and normalize data for the ML pipeline."""
 
-        # Additional processing logic here
-        # - Standardize industries
-        # - Calculate derived features
-        # - Handle missing values
+        def _normalize_industry(val: Any) -> str:
+            mapping = {
+                "tech": "Technology",
+                "technology": "Technology",
+                "software": "Technology",
+                "it": "Technology",
+                "financial services": "Finance",
+                "finance": "Finance",
+            }
+            if val is None or pd.isna(val):
+                return "Unknown"
+            val = str(val).strip().lower()
+            return mapping.get(val, val.title())
 
-        return processed
+        def _normalize_country(val: Any) -> str:
+            mapping = {
+                "us": "USA",
+                "usa": "USA",
+                "united states": "USA",
+                "united states of america": "USA",
+                "uk": "UK",
+                "united kingdom": "UK",
+            }
+            if val is None or pd.isna(val):
+                return "UNKNOWN"
+            val = str(val).strip().lower()
+            return mapping.get(val, val.upper())
+
+        cleaned_orgs: Dict[str, Dict] = {}
+        feature_frames: List[pd.DataFrame] = []
+
+        for org_id, data in org_data.items():
+            accounts = data.get("accounts", pd.DataFrame()).copy()
+            if not accounts.empty:
+                accounts["Industry"] = accounts["Industry"].apply(_normalize_industry)
+                accounts["BillingCountry"] = accounts["BillingCountry"].apply(_normalize_country)
+                accounts["AnnualRevenue"] = accounts["AnnualRevenue"].fillna(0)
+                accounts["NumberOfEmployees"] = accounts["NumberOfEmployees"].fillna(0)
+                accounts = accounts.drop_duplicates(subset="Id")
+
+                features = self.feature_engineer.create_account_features(accounts)
+                features["org_id"] = org_id
+                features["account_id"] = accounts["Id"].values
+                feature_frames.append(features)
+
+            cleaned_orgs[org_id] = {**data, "accounts": accounts}
+
+        feature_matrix = (
+            pd.concat(feature_frames, ignore_index=True) if feature_frames else pd.DataFrame()
+        )
+
+        return {"org_data": cleaned_orgs, "feature_matrix": feature_matrix, "labels": None}
 
     async def _train_model(self, processed_data: Dict[str, Any]):
         """Train or update the ML model"""

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import pytest
+
+from src.orchestrator import CrossSellOrchestrator
+
+async def test_industry_normalization_and_feature_matrix():
+    orch = CrossSellOrchestrator()
+    df = pd.DataFrame({
+        "Id": ["1", "2"],
+        "Name": ["A", "B"],
+        "Industry": ["tech", "Technology"],
+        "AnnualRevenue": [100000, 200000],
+        "NumberOfEmployees": [10, 20],
+        "BillingCountry": ["us", "United States"],
+        "CreatedDate": ["2020-01-01", "2021-01-01"],
+        "LastActivityDate": ["2021-06-01", "2021-06-02"],
+    })
+    processed = await orch._process_data({"org1": {"accounts": df}})
+    cleaned = processed["org_data"]["org1"]["accounts"]
+    assert list(cleaned["Industry"]) == ["Technology", "Technology"]
+    assert list(cleaned["BillingCountry"]) == ["USA", "USA"]
+    # Feature matrix should have two rows after dedup
+    fm = processed["feature_matrix"]
+    assert len(fm) == 2
+
+async def test_deduplication():
+    orch = CrossSellOrchestrator()
+    df = pd.DataFrame({
+        "Id": ["1", "1"],
+        "Name": ["A", "A"],
+        "Industry": ["tech", "tech"],
+        "AnnualRevenue": [100000, 100000],
+        "NumberOfEmployees": [10, 10],
+        "BillingCountry": ["us", "us"],
+        "CreatedDate": ["2020-01-01", "2020-01-01"],
+        "LastActivityDate": ["2021-06-01", "2021-06-01"],
+    })
+    processed = await orch._process_data({"org1": {"accounts": df}})
+    cleaned = processed["org_data"]["org1"]["accounts"]
+    assert len(cleaned) == 1
+    fm = processed["feature_matrix"]
+    assert len(fm) == 1


### PR DESCRIPTION
## Summary
- clean and normalize `industry` and `country` fields in orchestrator data processing
- create aggregate feature matrix during processing
- add unit tests for normalization and deduplication

## Testing
- `pytest -q tests/unit/test_processing.py`

------
https://chatgpt.com/codex/tasks/task_e_687cf3dd9e9c8332926eb709f5eb6458