### PR TITLE
Improve tests for auth & connectors

### DIFF
--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,15 +1,33 @@
 """Unit tests for API endpoints"""
+import jwt
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
+from unittest.mock import AsyncMock, MagicMock, patch
+from contextlib import asynccontextmanager
 
-from src.api.main import app
+from src.api.main import (
+    JWT_ALGORITHM,
+    JWT_SECRET_KEY,
+    app,
+    create_access_token,
+    get_db,
+)
+
+
+@asynccontextmanager
+async def _no_lifespan(app):
+    yield
+
+
+app.router.lifespan_context = _no_lifespan
 
 
 class TestHealthEndpoints:
     @pytest.mark.asyncio
     async def test_root_health(self):
         """Test root health endpoint"""
-        async with AsyncClient(app=app, base_url="http://test") as client:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.get("/")
         assert response.status_code == 200
 
@@ -18,7 +36,8 @@ class TestAuthentication:
     @pytest.mark.asyncio
     async def test_login_success(self):
         """Valid credentials should return a token"""
-        async with AsyncClient(app=app, base_url="http://test") as client:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post(
                 "/api/auth/token",
                 json={"username": "admin", "password": "password"},
@@ -28,14 +47,61 @@ class TestAuthentication:
         data = resp.json()
         assert "access_token" in data
         assert data["token_type"] == "bearer"
+        assert data["expires_in"] > 0
+
+        payload = jwt.decode(data["access_token"], JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+        assert payload["sub"] == "admin"
 
     @pytest.mark.asyncio
     async def test_login_invalid(self):
         """Invalid credentials should return 401"""
-        async with AsyncClient(app=app, base_url="http://test") as client:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post(
                 "/api/auth/token",
                 json={"username": "bad", "password": "wrong"},
             )
 
         assert resp.status_code == 401
+        assert resp.json()["detail"] == "Incorrect username or password"
+
+    @pytest.mark.asyncio
+    async def test_protected_endpoint_requires_token(self):
+        """Requests without a token should be rejected"""
+        mock_session = AsyncMock()
+        transport = ASGITransport(app=app)
+
+        async def override_db():
+            yield mock_session
+
+        app.dependency_overrides[get_db] = override_db
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/recommendations")
+        app.dependency_overrides.clear()
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_protected_endpoint_with_token(self):
+        """Valid token should allow access"""
+        token = create_access_token({"sub": "admin"})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        transport = ASGITransport(app=app)
+
+        async def override_db():
+            yield mock_session
+
+        app.dependency_overrides[get_db] = override_db
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/recommendations", headers=headers)
+        app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        assert resp.json() == []

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -38,3 +38,60 @@ class TestSalesforceConnector:
         assert isinstance(connector, BaseCRMConnector)
         assert connector.config.org_name == "Test Org"
         assert not connector._authenticated
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+class TestSalesforceConnectorAuth:
+    @pytest.mark.asyncio
+    async def test_authenticate_success(self, tmp_path):
+        cfg = SalesforceConfig(
+            org_id="1",
+            org_name="Test Org",
+            instance_url="https://example.com",
+            client_id="cid",
+            username="user",
+            password="pwd",
+            security_token="tok",
+            auth_type="password",
+            private_key_path=str(tmp_path / "key.pem"),
+        )
+        connector = SalesforceConnector(cfg)
+
+        async def mock_auth():
+            connector._authenticated = True
+            connector.config.access_token = "token"
+            return True
+
+        with patch.object(connector.token_manager, "get_token", AsyncMock(return_value=None)):
+            with patch.object(connector, "_auth_password", side_effect=mock_auth):
+                result = await connector.authenticate()
+
+        assert result is True
+        assert connector._authenticated
+        assert connector.config.access_token == "token"
+
+    @pytest.mark.asyncio
+    async def test_authenticate_failure(self, tmp_path):
+        cfg = SalesforceConfig(
+            org_id="1",
+            org_name="Test Org",
+            instance_url="https://example.com",
+            client_id="cid",
+            username="user",
+            password="pwd",
+            security_token="tok",
+            auth_type="password",
+            private_key_path=str(tmp_path / "key.pem"),
+        )
+        connector = SalesforceConnector(cfg)
+
+        async def mock_auth():
+            raise Exception("bad auth")
+
+        with patch.object(connector.token_manager, "get_token", AsyncMock(return_value=None)):
+            with patch.object(connector, "_auth_password", side_effect=mock_auth):
+                result = await connector.authenticate()
+
+        assert result is False
+        assert connector._authenticated is False


### PR DESCRIPTION
## Summary
- expand authentication tests with token claims and dependency overrides
- add success and failure tests for SalesforceConnector authentication

## Testing
- `pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6552bcd0833281b02c7ec77ab28d