### PR TITLE
Add Kubernetes manifests and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ python main.py --run-once
 - **Health Check**: http://localhost:8000/api/health
 - **Flower (Celery monitoring)**: http://localhost:5555
 
+## ⚓ Deployment
+
+Example Kubernetes manifests are available in [k8s/](k8s/).
+See [docs/deployment.md](docs/deployment.md) for steps to apply them and install Prometheus and Grafana.
+
+
 ## 🧪 Running Tests
 
 ```bash
@@ -173,7 +179,7 @@ Key environment variables (see `.env.example`):
 - [API Reference](docs/api.md)
 - [Architecture Details](docs/architecture.md)
 - [Development Guide](docs/development.md)
-- [Deployment Guide](docs/deployment.md)
+- [Deployment Guide (k8s manifests)](docs/deployment.md)
 
 ## 🤝 Contributing
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,33 @@
+# Deployment Guide
+
+This project can be deployed to a Kubernetes cluster. Example manifests live in the [`k8s/`](../k8s/) directory.
+
+## Build and Push the Image
+
+```bash
+docker build -t your-registry/multi-crm-cross-sell:latest .
+docker push your-registry/multi-crm-cross-sell:latest
+```
+
+## Apply Manifests
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl apply -f k8s/service.yaml
+kubectl apply -f k8s/ingress.yaml
+```
+
+Ensure an ingress controller is installed to expose the service.
+
+## Monitoring with Helm
+
+Helm value files are provided under `k8s/monitoring/` for Prometheus and Grafana.
+Install them with:
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+helm install monitoring prometheus-community/kube-prometheus-stack -f k8s/monitoring/prometheus-values.yaml
+helm install grafana grafana/grafana -f k8s/monitoring/grafana-values.yaml
+```

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cross-sell-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cross-sell
+  template:
+    metadata:
+      labels:
+        app: cross-sell
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/andre-profitt/multi-crm-cross-sell:latest
+          ports:
+            - containerPort: 8000

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cross-sell-ingress
+spec:
+  rules:
+    - host: cross-sell.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cross-sell-service
+                port:
+                  number: 80

--- a/k8s/monitoring/grafana-values.yaml
+++ b/k8s/monitoring/grafana-values.yaml
@@ -1,0 +1,5 @@
+# values.yaml for grafana/grafana chart
+adminUser: admin
+adminPassword: grafana
+service:
+  type: ClusterIP

--- a/k8s/monitoring/prometheus-values.yaml
+++ b/k8s/monitoring/prometheus-values.yaml
@@ -1,0 +1,6 @@
+# values.yaml for prometheus-community/kube-prometheus-stack
+prometheus:
+  service:
+    type: ClusterIP
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cross-sell-service
+spec:
+  selector:
+    app: cross-sell
+  ports:
+    - port: 80
+      targetPort: 8000
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add example Kubernetes manifests under `k8s/`
- include Helm values for Prometheus and Grafana
- document deployment steps in `docs/deployment.md`
- link manifests from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d701524a08332a801c872c25aa071