### PR TITLE
Fix CI requirements installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov
         pip install -r requirements.txt
+        pip install -r requirements-dev.txt
       continue-on-error: true
     
     - name: Run tests


### PR DESCRIPTION
## Summary
- install both prod and dev requirements in GitHub Actions

## Testing
- `pytest -q tests/test_basic.py -v`
- `pytest -q` *(fails: pydantic.errors.PydanticUserError)*

------
https://chatgpt.com/codex/tasks/task_e_687d701a71c883329db4db2fe344dade