### PR TITLE
Add integration and performance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ docker-compose exec app pytest --cov=src --cov-report=html
 
 # Run specific test category
 docker-compose exec app pytest tests/unit/
+
+# Integration tests
+docker-compose exec app pytest tests/integration
+
+# Performance tests
+docker-compose exec app pytest tests/performance
 ```
 
 ## 🛑 Stopping & Cleanup

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,4 +9,5 @@ markers =
     integration: marks tests as integration tests
     slow: marks tests as slow
     ml: marks tests as machine learning tests
+    performance: marks performance or load tests
 asyncio_mode = auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Test configuration and lightweight stubs for optional dependencies."""
+
 import asyncio
 import os
 import sys
@@ -48,6 +50,8 @@ if "torch" not in sys.modules:
     torch_stub.optim.Adam = _Adam
 
     def no_grad():
+        """Context manager stub used in place of torch.no_grad."""
+
         class _Ctx:
             def __enter__(self):
                 return None
@@ -61,6 +65,11 @@ if "torch" not in sys.modules:
     sys.modules["torch"] = torch_stub
     sys.modules["torch.nn"] = torch_stub.nn
     sys.modules["torch.optim"] = torch_stub.optim
+
+# Stub out heavy optional dependencies to avoid installation in CI
+for missing_pkg in ["shap", "xgboost"]:
+    if missing_pkg not in sys.modules:
+        sys.modules[missing_pkg] = types.ModuleType(missing_pkg)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,0 +1,87 @@
+"""Integration tests exercising orchestrator and Salesforce connector."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.connectors.salesforce import SalesforceConfig, SalesforceConnector
+from src.orchestrator import CrossSellOrchestrator
+
+
+@pytest.mark.asyncio
+async def test_salesforce_extract_all(tmp_path: Path) -> None:
+    """End-to-end extraction using mocked API calls."""
+    config = SalesforceConfig(
+        org_id="1",
+        org_name="Test Org",
+        instance_url="https://example.com",
+        client_id="cid",
+        username="user",
+        private_key_path=str(tmp_path / "key.pem"),
+    )
+    connector = SalesforceConnector(config)
+    connector._authenticated = True
+    connector.config.access_token = "token"
+
+    sample = pd.DataFrame({"Id": ["1"], "Name": ["Acme"]})
+    with patch.object(
+        SalesforceConnector, "_query_rest", AsyncMock(return_value=sample)
+    ), patch.object(SalesforceConnector, "_query_bulk", AsyncMock(return_value=sample)):
+        data = await connector.extract_all()
+
+    assert set(data.keys()) == {"accounts", "opportunities", "products", "contacts"}
+    for df in data.values():
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_pipeline_with_mocked_salesforce(tmp_path: Path) -> None:
+    """Run orchestrator pipeline with mocked Salesforce connector."""
+    cfg_path = tmp_path / "orgs.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "organizations": [
+                    {
+                        "org_id": "o1",
+                        "org_name": "Test Org",
+                        "instance_url": "https://example.com",
+                        "crm_type": "salesforce",
+                    }
+                ]
+            }
+        )
+    )
+
+    orchestrator = CrossSellOrchestrator(str(cfg_path))
+    orchestrator.initialize = AsyncMock()
+    orchestrator.scorer = MagicMock(is_trained=True)
+    await orchestrator.initialize()
+
+    mock_data = {
+        "accounts": pd.DataFrame({"Id": ["1"], "Name": ["Acme"]}),
+        "opportunities": pd.DataFrame(),
+        "products": pd.DataFrame(),
+        "contacts": pd.DataFrame(),
+    }
+
+    with patch(
+        "src.connectors.salesforce.SalesforceConnector.extract_all",
+        AsyncMock(return_value=mock_data),
+    ), patch.object(orchestrator, "_process_data", AsyncMock(return_value={})), patch.object(
+        orchestrator,
+        "_generate_recommendations",
+        AsyncMock(return_value=pd.DataFrame()),
+    ), patch.object(
+        orchestrator, "_save_recommendations", AsyncMock()
+    ), patch.object(
+        orchestrator, "_send_notifications", AsyncMock()
+    ):
+        await orchestrator.run_pipeline()
+
+    assert orchestrator.last_run_status.get("status") == "success"

--- a/tests/performance/test_pipeline_performance.py
+++ b/tests/performance/test_pipeline_performance.py
@@ -1,0 +1,63 @@
+"""Simple performance tests for the orchestrator pipeline."""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.orchestrator import CrossSellOrchestrator
+
+
+@pytest.mark.asyncio
+@pytest.mark.performance
+async def test_pipeline_run_time(tmp_path: Path) -> None:
+    """Ensure pipeline completes quickly with mocked connectors."""
+    cfg_path = tmp_path / "orgs.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "organizations": [
+                    {
+                        "org_id": "o1",
+                        "org_name": "Test Org",
+                        "instance_url": "https://example.com",
+                        "crm_type": "salesforce",
+                    }
+                ]
+            }
+        )
+    )
+
+    orchestrator = CrossSellOrchestrator(str(cfg_path))
+    orchestrator.initialize = AsyncMock()
+    orchestrator.scorer = MagicMock(is_trained=True)
+    await orchestrator.initialize()
+
+    mock_data = {
+        "accounts": pd.DataFrame(),
+        "opportunities": pd.DataFrame(),
+        "products": pd.DataFrame(),
+        "contacts": pd.DataFrame(),
+    }
+
+    with patch(
+        "src.connectors.salesforce.SalesforceConnector.extract_all",
+        AsyncMock(return_value=mock_data),
+    ), patch.object(orchestrator, "_process_data", AsyncMock(return_value={})), patch.object(
+        orchestrator,
+        "_generate_recommendations",
+        AsyncMock(return_value=pd.DataFrame()),
+    ), patch.object(
+        orchestrator, "_save_recommendations", AsyncMock()
+    ), patch.object(
+        orchestrator, "_send_notifications", AsyncMock()
+    ):
+        start = time.time()
+        await orchestrator.run_pipeline()
+        duration = time.time() - start
+
+    assert duration < 2
+    assert orchestrator.last_run_status.get("status") == "success"


### PR DESCRIPTION
## Summary
- add basic end-to-end Salesforce tests under `tests/integration`
- add simple pipeline timing test under `tests/performance`
- document new test suites in README
- register `performance` marker in pytest config
- stub heavy optional dependencies for tests

## Testing
- `pre-commit run --files tests/conftest.py tests/integration/test_end_to_end.py tests/performance/test_pipeline_performance.py README.md pytest.ini`
- `pytest -q tests/integration/test_end_to_end.py tests/performance/test_pipeline_performance.py tests/test_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_687d701b5158833289643601f1ba3130